### PR TITLE
Enable displaying constrast maps descriptions

### DIFF
--- a/api/src/brain_cockpit/endpoints/features_explorer.py
+++ b/api/src/brain_cockpit/endpoints/features_explorer.py
@@ -184,7 +184,7 @@ def create_endpoints_one_features_dataset(bc, id, dataset):
     meshes, subjects, tasks_contrasts, sides = parse_metadata(df)
 
     # ROUTES
-    # Define a series of enpoints to expose contrasts, meshes, etc
+    # Define a series of endpoints to expose contrasts, meshes, etc
     info_endpoint = f"/datasets/{id}/info"
     subjects_endpoint = f"/datasets/{id}/subjects"
     contrasts_endpoint = f"/datasets/{id}/contrast_labels"

--- a/web/src/components/colorbar/index.tsx
+++ b/web/src/components/colorbar/index.tsx
@@ -114,7 +114,7 @@ const Colorbar = ({
           <foreignObject
             className="unit-container"
             x={-margin.right - 25}
-            y={offset - 5}
+            y={offset - 15}
             width="100"
             height="20"
             textAnchor="middle"

--- a/web/src/components/paneControls/index.tsx
+++ b/web/src/components/paneControls/index.tsx
@@ -1,5 +1,6 @@
 import { Button, ButtonGroup, Colors, Icon, Switch } from "@blueprintjs/core";
 import { IconName } from "@blueprintjs/icons";
+import { Tooltip2 } from "@blueprintjs/popover2";
 import { Select2 } from "@blueprintjs/select";
 import React from "react";
 
@@ -31,6 +32,7 @@ interface PaneControlsInput {
   title?: string;
   iconLeft?: IconName;
   iconRight?: IconName;
+  tooltip?: string;
 }
 
 interface PaneControlsRow {
@@ -185,6 +187,18 @@ const PaneControls = ({ rows }: IProps) => {
                         <span key={`input-${inputIndex}`}>{input.value}</span>
                       );
                       break;
+                  }
+
+                  if (input.tooltip) {
+                    element = (
+                      <Tooltip2
+                        content={input.tooltip}
+                        placement={"right"}
+                        key={`input-${inputIndex}`}
+                      >
+                        {element}
+                      </Tooltip2>
+                    );
                   }
 
                   return element;

--- a/web/src/components/paneControls/style.scss
+++ b/web/src/components/paneControls/style.scss
@@ -21,7 +21,6 @@
 
     & .bp4-button,
     & .custom-button {
-      background-color: $light-gray5;
       height: 30px;
     }
 

--- a/web/src/constants/index.tsx
+++ b/web/src/constants/index.tsx
@@ -84,7 +84,13 @@ export interface DatasetDescriptions {
   [protocol: string]: {
     description: string;
     maps: {
-      [condition: string]: string;
+      [condition: string]: {
+        contrast: boolean;
+        description?: string;
+        conditions?: {
+          [condition: string]: number;
+        };
+      };
     };
   };
 }

--- a/web/src/views/surface/index.tsx
+++ b/web/src/views/surface/index.tsx
@@ -166,7 +166,7 @@ const SurfaceExplorer = ({ datasetId }: SurfaceViewProps) => {
     if (state.panes === undefined) {
       setState({ panes: {} });
     }
-  }, [datasetId, setState]);
+  }, [datasetId, setState, state.panes]);
 
   const selectedVoxels = Object.keys(state.panes).map((paneId: any) => [
     paneId,

--- a/web/src/views/surface/index.tsx
+++ b/web/src/views/surface/index.tsx
@@ -126,7 +126,7 @@ const SurfaceExplorer = ({ datasetId }: SurfaceViewProps) => {
   const [meshTypeLabels, setMeshTypeLabels] = useState<string[]>([]);
   const [hemiLabels, setHemiLabels] = useState<string[]>([]);
   const [unit, setUnit] = useState<string | undefined>(undefined);
-  const [datasetDescriptions] = useState<any>({});
+  const [descriptions, setDescriptions] = useState<any>({});
 
   // Load state from url
   const [state, setState] = useSurfaceState();
@@ -134,6 +134,9 @@ const SurfaceExplorer = ({ datasetId }: SurfaceViewProps) => {
   // Initialise all pane state variables
   useEffect(() => {
     const datasetInfo = server.get<DatasetInfo>(`/datasets/${datasetId}/info`);
+    const datasetDescriptions = server.get<DatasetInfo>(
+      `/datasets/${datasetId}/descriptions`
+    );
 
     datasetInfo.then((value) => {
       setSubjectLabels(value.data.subjects);
@@ -154,6 +157,10 @@ const SurfaceExplorer = ({ datasetId }: SurfaceViewProps) => {
       }
 
       setUnit(value.data.unit);
+    });
+
+    datasetDescriptions.then((value) => {
+      setDescriptions(value.data);
     });
 
     if (state.panes === undefined) {
@@ -543,7 +550,7 @@ const SurfaceExplorer = ({ datasetId }: SurfaceViewProps) => {
                   meshTypeLabels={meshTypeLabels}
                   hemiLabels={hemiLabels}
                   unit={unit}
-                  datasetDescriptions={datasetDescriptions}
+                  datasetDescriptions={descriptions}
                   filterSurface={filterSurface}
                   thresholdLow={thresholdLow}
                   thresholdHigh={thresholdHigh}

--- a/web/src/views/surface/surfacePane/index.tsx
+++ b/web/src/views/surface/surfacePane/index.tsx
@@ -623,6 +623,7 @@ const SurfacePane = ({
                   iconLeft: "person",
                   iconRight: "people",
                   title: "Mean across subjects",
+                  tooltip: "Toggle subjects' mean",
                 },
               ],
             },
@@ -660,6 +661,7 @@ const SurfacePane = ({
                     }
                   },
                   iconActive: "manual",
+                  tooltip: "Toggle description",
                 },
               ],
             },

--- a/web/src/views/surface/surfacePane/index.tsx
+++ b/web/src/views/surface/surfacePane/index.tsx
@@ -479,31 +479,25 @@ const SurfacePane = ({
       newDescriptions.push([task, datasetDescriptions[task]?.description]);
     }
 
-    // Add contrast / condition description
+    // Add contrast / conditions description
     const contrast = contrastLabels[state.contrast ?? 0]?.contrast;
-    if (contrast !== undefined) {
-      newDescriptions.push([
-        contrast,
-        datasetDescriptions[task]?.maps[contrast],
-      ]);
-    }
+    const entry = datasetDescriptions[task]?.maps[contrast];
 
-    // If map is contrast, try to add the descriptions
-    // of all conditions it results from
-    if (
-      task !== undefined &&
-      contrast !== undefined &&
-      datasetDescriptions[task] !== undefined &&
-      contrast.indexOf("-") !== -1
-    ) {
-      const conditions = contrast.split("-");
-      for (const condition of conditions) {
-        if (condition in datasetDescriptions[task]?.maps) {
+    if (entry !== undefined) {
+      if (entry.contrast) {
+        for (const condition in entry.conditions) {
           newDescriptions.push([
-            condition,
-            datasetDescriptions[task]?.maps[condition],
+            `(${entry.conditions[condition] >= 0 ? "+" : ""}${
+              entry.conditions[condition]
+            }) ${condition}`,
+            datasetDescriptions[task].maps[condition].description,
           ]);
         }
+      } else {
+        newDescriptions.push([
+          contrast,
+          datasetDescriptions[task]?.maps[contrast].description,
+        ]);
       }
     }
 

--- a/web/src/views/surface/surfacePane/index.tsx
+++ b/web/src/views/surface/surfacePane/index.tsx
@@ -485,6 +485,9 @@ const SurfacePane = ({
 
     if (entry !== undefined) {
       if (entry.contrast) {
+        newDescriptions.push([
+          "This contrast map combines the following conditions:",
+        ]);
         for (const condition in entry.conditions) {
           newDescriptions.push([
             `(${entry.conditions[condition] >= 0 ? "+" : ""}${
@@ -514,7 +517,13 @@ const SurfacePane = ({
               {descriptions.map((description: any) => {
                 return (
                   <p key={`description-${description[0]}`}>
-                    <strong>{description[0]}:</strong> {description[1]}
+                    {description.length > 1 ? (
+                      <>
+                        <strong>{description[0]}:</strong> {description[1]}
+                      </>
+                    ) : (
+                      description[0]
+                    )}
                   </p>
                 );
               })}


### PR DESCRIPTION
This PR connects frontend to `descriptions` endpoint in backend.
It mostly:
- fetches descriptions from backend
- updates descriptions parsing
- fixes units positioning in colorbar
- adds tooltips to some control buttons