### PR TITLE
Allow disabling cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 - large surface fMRI datasets projected on surface meshes
 - alignments computed between brains, such as those computed with [fugw](https://alexisthual.github.io/fugw/index.html)
 
-You can try our [online demo](https://brain-cockpit.athual.fr/)!
+🚀 You can try our [online demo](https://brain-cockpit.tc.humanbrainproject.eu/) displaying the [Individual Brain Charting dataset](https://individual-brain-charting.github.io/docs/), a vast collection of fMRI protocols collected in a small number of human participants.
+This project was deployed with [EBRAINS](https://www.ebrains.eu/).
 
 ![Screenshot features dataset view](https://raw.githubusercontent.com/alexisthual/brain-cockpit/main/doc/images/main_screenshot.png)
 

--- a/api/src/brain_cockpit/endpoints/alignments_explorer.py
+++ b/api/src/brain_cockpit/endpoints/alignments_explorer.py
@@ -1,23 +1,20 @@
+"""Util functions to create Alignments Explorer endpoints."""
+
 import os
 import pickle
-
 from pathlib import Path
 
 import nibabel as nib
 import numpy as np
 import pandas as pd
+from flask import jsonify, request, send_from_directory
 
 from brain_cockpit.scripts.gifti_to_gltf import create_dataset_glft_files
 from brain_cockpit.utils import console, load_dataset_description
-from flask import jsonify, request, send_from_directory
 
 
 def create_endpoints_one_alignment_dataset(bc, id, dataset):
-    """
-    For a given alignment dataset, generate endpoints
-    serving dataset meshes and alignment transforms.
-    """
-
+    """Create all API endpoints for exploring a given Alignments dataset."""
     df, dataset_path = load_dataset_description(
         config_path=bc.config_path, dataset_path=dataset["path"]
     )
@@ -126,8 +123,7 @@ def create_endpoints_one_alignment_dataset(bc, id, dataset):
 
 
 def create_all_endpoints(bc):
-    """Create endpoints for all available alignments datasets."""
-
+    """Create endpoints for all available Alignments datasets."""
     if "alignments" in bc.config and "datasets" in bc.config["alignments"]:
         # Iterate through each alignment dataset
         for dataset_id, dataset in bc.config["alignments"]["datasets"].items():

--- a/api/src/brain_cockpit/endpoints/features_explorer.py
+++ b/api/src/brain_cockpit/endpoints/features_explorer.py
@@ -1,22 +1,24 @@
+"""Util functions to create Features Explorer endpoints."""
+
 import json
 import os
-
 from pathlib import Path
 
 import nibabel as nib
 import numpy as np
 import pandas as pd
+from flask import jsonify, request, send_from_directory
 
 from brain_cockpit import utils
 from brain_cockpit.scripts.gifti_to_gltf import create_dataset_glft_files
 from brain_cockpit.utils import console, load_dataset_description
-from flask import jsonify, request, send_from_directory
 
 # UTIL FUNCTIONS
 # These functions are useful for loading data
 
 
 def hemi_to_side(hemi):
+    """Transform hemisphere label from nilearn to HCP."""
     if hemi == "left":
         return "lh"
     elif hemi == "right":
@@ -25,6 +27,7 @@ def hemi_to_side(hemi):
 
 
 def side_to_hemi(hemi):
+    """Transform hemisphere label from HCP to nilearn."""
     if hemi == "lh":
         return "left"
     elif hemi == "rh":
@@ -33,6 +36,7 @@ def side_to_hemi(hemi):
 
 
 def multiindex_to_nested_dict(df):
+    """Transform DataFrame with multiple indices to python dict."""
     if isinstance(df.index, pd.core.indexes.multi.MultiIndex):
         return dict(
             (k, multiindex_to_nested_dict(df.loc[k]))
@@ -46,7 +50,8 @@ def multiindex_to_nested_dict(df):
 
 
 def parse_metadata(df):
-    """
+    """Parse metadata Dataframe.
+
     Parameters
     ----------
     df: pandas DataFrame
@@ -84,11 +89,12 @@ def parse_metadata(df):
 
 
 def create_endpoints_one_features_dataset(bc, id, dataset):
-    memory = utils.get_memory(bc)
+    """Create all API endpoints for exploring a given Features dataset."""
 
-    @memory.cache
+    @utils.bc_cache(bc)
     def load_data(df, config_path=None, dataset_path=None):
-        """
+        """Load data used in endpoints.
+
         Parameters
         ----------
         dataset_path: str
@@ -507,8 +513,7 @@ def create_endpoints_one_features_dataset(bc, id, dataset):
 
 
 def create_all_endpoints(bc):
-    """Create endpoints for all available surface datasets."""
-
+    """Create endpoints for all available Features datasets."""
     if "features" in bc.config and "datasets" in bc.config["features"]:
         # Iterate through each surface dataset
         for dataset_id, dataset in bc.config["features"]["datasets"].items():


### PR DESCRIPTION
This PR allows not using a joblib cache if the config file does not specify a cache folder.
This is useful if the dataset is very big and won't fit twice on disk.

It also adds missing docstrings and updates the README.