### PR TITLE
Handle missing descriptions in frontend

### DIFF
--- a/web/src/views/surface/surfacePane/index.tsx
+++ b/web/src/views/surface/surfacePane/index.tsx
@@ -493,13 +493,13 @@ const SurfacePane = ({
             `(${entry.conditions[condition] >= 0 ? "+" : ""}${
               entry.conditions[condition]
             }) ${condition}`,
-            datasetDescriptions[task].maps[condition].description,
+            datasetDescriptions[task]?.maps[condition]?.description,
           ]);
         }
       } else {
         newDescriptions.push([
           contrast,
-          datasetDescriptions[task]?.maps[contrast].description,
+          datasetDescriptions[task]?.maps[contrast]?.description,
         ]);
       }
     }


### PR DESCRIPTION
Fix `Uncaught TypeError: v[o].maps[e] is undefined` raised when description is missing.